### PR TITLE
Reload image on src change

### DIFF
--- a/addon/components/img-lazy.js
+++ b/addon/components/img-lazy.js
@@ -68,7 +68,7 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    if (this._src !== this.getAttr('src')) {
+    if (this._src !== this.src) {
       this.loadImage()
     }
   },

--- a/addon/components/img-lazy.js
+++ b/addon/components/img-lazy.js
@@ -65,7 +65,7 @@ export default Component.extend({
     get(this, 'observer').observe(this)
   },
 
-  didReceiveAttrs() {
+  didUpdateAttrs() {
     this._super(...arguments);
 
     if (this._src !== this.src) {

--- a/addon/components/img-lazy.js
+++ b/addon/components/img-lazy.js
@@ -65,6 +65,14 @@ export default Component.extend({
     get(this, 'observer').observe(this)
   },
 
+  didReceiveAttrs() {
+    this._super(...arguments);
+
+    if (this._src !== this.getAttr('src')) {
+      this.loadImage()
+    }
+  },
+
   willDestroyElement() {
     get(this, 'observer').unobserve(this)
   },


### PR DESCRIPTION
Fixes https://github.com/topaxi/ember-img-lazy/issues/7 where `src` property changes do not re-render or reload the image.

Based on suggestion from @courthead.

Passes current tests.